### PR TITLE
Add market data libraries to requirements

### DIFF
--- a/market-api/requirements.txt
+++ b/market-api/requirements.txt
@@ -9,6 +9,13 @@ pyarrow==16.1.0
 orjson==3.10.7
 akshare==1.12.99
 
+# Market Data APIs
+tushare==1.2.89
+yfinance==0.2.40
+
+# Quant Frameworks
+backtrader==1.9.78.123
+
 # Database & ORM
 sqlalchemy==2.0.23
 alembic==1.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,11 @@ akshare==1.12.85
 
 # 量化框架
 qlib==0.9.4
+backtrader==1.9.78.123
+
+# 金融数据接口
+tushare==1.2.89
+yfinance==0.2.40
 
 # 系统监控
 psutil==5.9.6


### PR DESCRIPTION
## Summary
- add backtrader, tushare, and yfinance to the root requirements with appropriate grouping
- align the market API requirements with the same market data and backtesting dependencies for standalone deployments

## Testing
- `pip install -r requirements.txt` *(fails: numpy==1.24.4 build breaks under Python 3.12 because distutils is unavailable)*
- `pip install -r market-api/requirements.txt` *(fails: pinned akshare==1.12.99 is no longer published on PyPI)*

------
https://chatgpt.com/codex/tasks/task_e_68cdb25abe5c8325a8264ccfb9001b67