### PR TITLE
Align FastAPI/Pydantic dependencies across services

### DIFF
--- a/market-api/app/config.py
+++ b/market-api/app/config.py
@@ -1,4 +1,4 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import List
 
 
@@ -75,9 +75,10 @@ class Settings(BaseSettings):
     GC_THRESHOLD: int = 1000
     OBJECT_POOL_SIZE: int = 100
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = True
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=True,
+    )
 
 
 settings = Settings()

--- a/market-api/requirements.txt
+++ b/market-api/requirements.txt
@@ -1,7 +1,7 @@
 # Core Framework
 fastapi==0.114.0
 uvicorn[standard]==0.30.6
-pydantic==1.10.15
+pydantic==2.5.0
 
 # Data Processing
 pandas==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # NAXS项目依赖包
 
 # 核心框架
-fastapi==0.104.1
+fastapi==0.114.0
 uvicorn[standard]==0.24.0
 pydantic==2.5.0
 pydantic-settings==2.1.0


### PR DESCRIPTION
## Summary
- Align both requirements files on FastAPI 0.114.0 paired with Pydantic 2.5.0 so the services share a compatible stack.
- Update the market API settings object to the Pydantic v2 `SettingsConfigDict` style configuration API.

## Testing
- `python - <<'PY' ...` (instantiates key Pydantic models to ensure the v2 stack works)
- `pytest market-api/tests/test_performance.py -k cache_performance` *(fails: aioredis raises `TypeError: duplicate base class TimeoutError` under Python 3.12)*

------
https://chatgpt.com/codex/tasks/task_e_68ce47d0387c8325a2cdedbb07bc12e4