### PR TITLE
feat: add Fastify trace plugin and unified error handling

### DIFF
--- a/apps/backend/src/middleware/errorHandler.ts
+++ b/apps/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,44 @@
+import type { FastifyError, FastifyInstance } from 'fastify';
+import { AppError, err } from '../utils/errors';
+
+const DEFAULT_ERROR_CODE = 'INTERNAL_ERROR';
+
+export function registerErrorHandler(app: FastifyInstance): void {
+  app.setErrorHandler((error, request, reply) => {
+    const traceId = request.traceId ?? '';
+    request.log.error({ err: error, traceId }, 'request failed');
+
+    if (error instanceof AppError) {
+      reply
+        .status(error.statusCode)
+        .send(
+          err({
+            code: error.code,
+            message: error.message,
+            traceId,
+            details: error.details,
+          }),
+        );
+      return;
+    }
+
+    const fastifyError = error as FastifyError & {
+      cause?: unknown;
+      validation?: unknown;
+    };
+
+    const statusCode = typeof fastifyError.statusCode === 'number' ? fastifyError.statusCode : 500;
+    const code = typeof fastifyError.code === 'string' ? fastifyError.code : DEFAULT_ERROR_CODE;
+    const message = statusCode >= 500 ? 'Internal server error' : fastifyError.message;
+    const details = statusCode >= 500 ? undefined : fastifyError.validation ?? fastifyError.cause;
+
+    reply.status(statusCode).send(
+      err({
+        code,
+        message,
+        traceId,
+        details,
+      }),
+    );
+  });
+}

--- a/apps/backend/src/plugins/trace.ts
+++ b/apps/backend/src/plugins/trace.ts
@@ -1,0 +1,37 @@
+import fp from 'fastify-plugin';
+import { randomUUID } from 'node:crypto';
+import type { FastifyInstance } from 'fastify';
+
+const TRACE_HEADER = 'x-trace-id';
+
+function extractTraceId(rawHeader: string | string[] | undefined): string | undefined {
+  if (typeof rawHeader === 'string') {
+    return rawHeader.trim() === '' ? undefined : rawHeader.trim();
+  }
+
+  if (Array.isArray(rawHeader) && rawHeader.length > 0) {
+    const first = rawHeader[0]?.trim();
+    return first ? first : undefined;
+  }
+
+  return undefined;
+}
+
+async function tracePlugin(fastify: FastifyInstance): Promise<void> {
+  fastify.decorateRequest('traceId', '');
+
+  fastify.addHook('onRequest', async (request, reply) => {
+    const providedTraceId = extractTraceId(request.headers[TRACE_HEADER]);
+    const traceId = providedTraceId ?? randomUUID();
+
+    request.traceId = traceId;
+    reply.header(TRACE_HEADER, traceId);
+  });
+}
+
+export default fp(tracePlugin, {
+  fastify: '4.x',
+  name: 'trace-plugin',
+});
+
+export { TRACE_HEADER };

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1,0 +1,34 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import tracePlugin from './plugins/trace';
+import { registerErrorHandler } from './middleware/errorHandler';
+
+export async function buildServer(): Promise<FastifyInstance> {
+  const app = Fastify({
+    logger: true,
+  });
+
+  await app.register(tracePlugin);
+  registerErrorHandler(app);
+
+  app.get('/healthz', async (request) => ({ status: 'ok', traceId: request.traceId }));
+
+  return app;
+}
+
+async function start(): Promise<void> {
+  const app = await buildServer();
+  const port = Number(process.env.PORT ?? 8080);
+  const host = process.env.HOST ?? '0.0.0.0';
+
+  try {
+    await app.listen({ port, host });
+    app.log.info({ port, host }, 'Server started');
+  } catch (error) {
+    app.log.error({ err: error }, 'Failed to start server');
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  void start();
+}

--- a/apps/backend/src/types/fastify.d.ts
+++ b/apps/backend/src/types/fastify.d.ts
@@ -1,0 +1,7 @@
+import 'fastify';
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    traceId: string;
+  }
+}

--- a/apps/backend/src/utils/errors.ts
+++ b/apps/backend/src/utils/errors.ts
@@ -1,0 +1,39 @@
+export interface ErrorResponse {
+  code: string;
+  message: string;
+  details?: unknown;
+  traceId: string;
+  timestamp: string;
+}
+
+export class AppError extends Error {
+  public readonly code: string;
+
+  public readonly statusCode: number;
+
+  public readonly details?: unknown;
+
+  constructor(code: string, message: string, statusCode = 500, details?: unknown) {
+    super(message);
+    this.code = code;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+interface ErrorParams {
+  code: string;
+  message: string;
+  traceId: string;
+  details?: unknown;
+}
+
+export function err({ code, message, traceId, details }: ErrorParams): ErrorResponse {
+  return {
+    code,
+    message,
+    ...(details === undefined ? {} : { details }),
+    traceId,
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/apps/backend/test/trace-and-error.test.ts
+++ b/apps/backend/test/trace-and-error.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { buildServer } from '../src/server';
+import { AppError } from '../src/utils/errors';
+
+async function createServer(): Promise<FastifyInstance> {
+  return buildServer();
+}
+
+describe('trace plugin and error handler', () => {
+  it('generates a trace id when header is missing', async () => {
+    const server = await createServer();
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/healthz',
+    });
+
+    const traceIdHeader = response.headers['x-trace-id'];
+
+    expect(typeof traceIdHeader).toBe('string');
+    expect((traceIdHeader as string).length).toBeGreaterThan(0);
+
+    await server.close();
+  });
+
+  it('reuses the first value when header is an array', async () => {
+    const server = await createServer();
+
+    const traceId = 'trace-array-1';
+    const response = await server.inject({
+      method: 'GET',
+      url: '/healthz',
+      headers: {
+        'x-trace-id': [traceId, 'ignored'],
+      },
+    });
+
+    expect(response.headers['x-trace-id']).toBe(traceId);
+
+    await server.close();
+  });
+
+  it('returns standard error body when route throws', async () => {
+    const server = await createServer();
+
+    server.get('/boom', () => {
+      throw new AppError('BAD_REQUEST', 'Request failed', 400, { reason: 'boom' });
+    });
+
+    await server.ready();
+
+    const traceId = 'trace-error-1';
+    const response = await server.inject({
+      method: 'GET',
+      url: '/boom',
+      headers: {
+        'x-trace-id': traceId,
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.headers['x-trace-id']).toBe(traceId);
+
+    const payload = response.json();
+
+    expect(payload).toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Request failed',
+      traceId,
+      details: { reason: 'boom' },
+    });
+
+    expect(typeof payload.timestamp).toBe('string');
+    expect(Number.isNaN(Date.parse(payload.timestamp))).toBe(false);
+
+    await server.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Fastify trace plugin that normalises incoming x-trace-id headers and ensures every request gets one
- introduce shared error utilities and register an error handler that emits standardised error payloads
- cover the trace propagation and error formatting behaviour with HTTP injection tests

## Testing
- pnpm -w test *(fails: --workspace-root may only be used inside a workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4dd95f908325867b0a9d839b5eea