### PR TITLE
Fix frontend API/WebSocket configuration and notification stability

### DIFF
--- a/apps/web/src/components/Dashboard/EnhancedDashboard.tsx
+++ b/apps/web/src/components/Dashboard/EnhancedDashboard.tsx
@@ -44,6 +44,7 @@ import { useWebSocket } from '../../hooks/useWebSocket';
 import { useRealTimeData } from '../../hooks/useRealTimeData';
 import { useAgentStatus } from '../../hooks/useAgentStatus';
 import { useSystemMetrics } from '../../hooks/useSystemMetrics';
+import { WEBSOCKET_URL } from '../../config/environment';
 
 // 数据类型定义
 interface MarketData {
@@ -688,7 +689,7 @@ export const EnhancedDashboard: React.FC<EnhancedDashboardProps> = ({ className 
   
   // WebSocket连接状态
   const { isConnected, connectionStatus } = useWebSocket({
-    url: 'ws://localhost:8765',
+    url: WEBSOCKET_URL,
     onMessage: (data) => {
       // 处理实时数据更新
       console.log('WebSocket data:', data);

--- a/apps/web/src/components/Layout/Layout.tsx
+++ b/apps/web/src/components/Layout/Layout.tsx
@@ -136,7 +136,11 @@ const GlobalLoadingOverlay: React.FC = () => {
 
 // 全局通知组件
 const GlobalNotifications: React.FC = () => {
-  const { notifications } = useUI();
+  const { notifications: uiNotifications } = useUI();
+  const notifications = React.useMemo(
+    () => (Array.isArray(uiNotifications) ? uiNotifications : []),
+    [uiNotifications]
+  );
   const [visibleNotifications, setVisibleNotifications] = React.useState<string[]>([]);
 
   // 显示最新的通知

--- a/apps/web/src/config/environment.ts
+++ b/apps/web/src/config/environment.ts
@@ -1,0 +1,61 @@
+const isBrowser = typeof window !== 'undefined';
+
+const DEFAULT_API_PORT = 3001;
+const DEFAULT_WS_PORT = 8765;
+
+const sanitizeUrl = (url: string) => {
+  if (!url || !url.endsWith('/')) {
+    return url;
+  }
+  return url.endsWith('://') ? url : url.slice(0, -1);
+};
+
+const resolveHostname = () => {
+  if (!isBrowser) {
+    return 'localhost';
+  }
+  return window.location.hostname || 'localhost';
+};
+
+const resolveHttpProtocol = () => {
+  if (!isBrowser) {
+    return 'http:';
+  }
+  return window.location.protocol === 'https:' ? 'https:' : 'http:';
+};
+
+const resolveWsProtocol = () => {
+  if (!isBrowser) {
+    return 'ws:';
+  }
+  return window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+};
+
+const getEnvValue = (key: string): string | undefined => {
+  const value = import.meta.env?.[key as keyof ImportMetaEnv];
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value.trim();
+  }
+  return undefined;
+};
+
+const defaultApiBaseUrl = () => {
+  const hostname = resolveHostname();
+  const protocol = resolveHttpProtocol();
+  return `${protocol}//${hostname}:${DEFAULT_API_PORT}`;
+};
+
+const defaultWebSocketUrl = () => {
+  const hostname = resolveHostname();
+  const protocol = resolveWsProtocol();
+  return `${protocol}//${hostname}:${DEFAULT_WS_PORT}`;
+};
+
+export const API_BASE_URL = sanitizeUrl(
+  getEnvValue('VITE_API_BASE_URL') ?? defaultApiBaseUrl()
+);
+
+export const WEBSOCKET_URL = getEnvValue('VITE_WS_URL') ?? defaultWebSocketUrl();
+
+export const getResolvedApiBaseUrl = () => API_BASE_URL;
+export const getResolvedWebSocketUrl = () => WEBSOCKET_URL;

--- a/apps/web/src/hooks/useRealTimeData.ts
+++ b/apps/web/src/hooks/useRealTimeData.ts
@@ -4,6 +4,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useWebSocket } from './useWebSocket';
 import apiService from '../services/api';
+import { WEBSOCKET_URL } from '../config/environment';
 
 // 数据类型定义
 interface MarketData {
@@ -74,7 +75,7 @@ export const useRealTimeData = (config: UseRealTimeDataConfig): UseRealTimeDataR
 
   // WebSocket连接
   const { isConnected, sendMessage } = useWebSocket({
-    url: 'ws://localhost:8765',
+    url: WEBSOCKET_URL,
     enabled: enabled && useWS,
     onOpen: () => {
       setConnectionStatus('connected');

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -3,6 +3,7 @@
 import axios from 'axios';
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import type { MarketData, Strategy, StockRecommendation, ChatMessage } from '../store';
+import { API_BASE_URL } from '../config/environment';
 
 // API响应接口
 interface ApiResponse<T = any> {
@@ -80,7 +81,7 @@ class ApiService {
   private client: AxiosInstance;
   private baseURL: string;
 
-  constructor(baseURL: string = 'http://localhost:8001') {
+  constructor(baseURL: string = API_BASE_URL) {
     this.baseURL = baseURL;
     this.client = axios.create({
       baseURL,

--- a/apps/web/src/services/websocket.ts
+++ b/apps/web/src/services/websocket.ts
@@ -1,6 +1,6 @@
 // WebSocket服务 - 实时数据连接
 
-import { io, Socket } from 'socket.io-client';
+import { WEBSOCKET_URL } from '../config/environment';
 import { useAppStore } from '../store';
 
 // WebSocket消息类型
@@ -20,17 +20,23 @@ interface SubscriptionConfig {
 // 连接状态
 type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'reconnecting' | 'error';
 
+const HEARTBEAT_INTERVAL = 30000;
+const CONNECTION_TIMEOUT = 10000;
+
 class WebSocketService {
-  private socket: Socket | null = null;
+  private socket: WebSocket | null = null;
   private url: string;
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 5;
   private reconnectDelay = 1000;
-  private heartbeatInterval: number | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private manualDisconnect = false;
+  private pendingToken?: string;
   private subscriptions = new Map<string, SubscriptionConfig>();
   private messageHandlers = new Map<string, (data: any) => void>();
   private status: ConnectionStatus = 'disconnected';
-  
+
   // 统计信息
   private stats = {
     messagesReceived: 0,
@@ -40,258 +46,235 @@ class WebSocketService {
     lastDisconnected: null as Date | null,
   };
 
-  constructor(url: string = 'ws://localhost:8765') {
+  constructor(url: string = WEBSOCKET_URL) {
     this.url = url;
     this.setupStoreSubscription();
   }
 
   // 设置store订阅，监听状态变化
   private setupStoreSubscription() {
-    // 监听WebSocket状态变化
-    useAppStore.subscribe(
-      (_state) => {
-        // 可以在这里处理状态变化
-      }
-    );
+    useAppStore.subscribe(() => undefined);
+  }
+
+  private clearReconnectTimer() {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private stopHeartbeat() {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
   }
 
   // 连接WebSocket
   async connect(token?: string): Promise<void> {
-    try {
-      if (this.socket?.connected) {
-        console.log('WebSocket already connected');
-        return;
+    if (token) {
+      this.pendingToken = token;
+    }
+
+    if (this.socket && (this.socket.readyState === WebSocket.OPEN || this.socket.readyState === WebSocket.CONNECTING)) {
+      if (token && this.socket.readyState === WebSocket.OPEN) {
+        this.sendMessage({
+          type: 'auth',
+          data: { token },
+        });
       }
+      return;
+    }
 
-      this.setStatus('connecting');
-      console.log(`Connecting to WebSocket: ${this.url}`);
+    this.manualDisconnect = false;
+    this.setStatus('connecting');
+    this.clearReconnectTimer();
 
-      // 创建Socket.IO连接
-      this.socket = io(this.url, {
-        transports: ['websocket'],
-        timeout: 10000,
-        reconnection: false, // 我们手动处理重连
-        auth: token ? { token } : undefined,
-      });
+    return new Promise((resolve, reject) => {
+      try {
+        const socket = new WebSocket(this.url);
+        this.socket = socket;
 
-      // 设置事件监听器
-      this.setupEventListeners();
-
-      // 等待连接建立
-      await new Promise<void>((resolve, reject) => {
+        let hasOpened = false;
         const timeout = setTimeout(() => {
-          reject(new Error('Connection timeout'));
-        }, 10000);
+          if (socket.readyState !== WebSocket.OPEN) {
+            socket.close();
+            reject(new Error('Connection timeout'));
+          }
+        }, CONNECTION_TIMEOUT);
 
-        this.socket!.on('connect', () => {
+        socket.onopen = () => {
           clearTimeout(timeout);
+          hasOpened = true;
+          this.handleOpen();
+
+          if (this.pendingToken) {
+            this.sendMessage({
+              type: 'auth',
+              data: { token: this.pendingToken },
+            });
+          }
+
           resolve();
-        });
+        };
 
-        this.socket!.on('connect_error', (error) => {
+        socket.onmessage = (event) => {
+          this.handleIncomingMessage(event.data);
+        };
+
+        socket.onerror = (event) => {
           clearTimeout(timeout);
-          reject(error);
-        });
-      });
+          const error = event instanceof ErrorEvent ? event.error : new Error('WebSocket connection error');
+          console.error('WebSocket connection error:', error);
+          this.handleError(error);
+          if (!hasOpened) {
+            reject(error instanceof Error ? error : new Error('WebSocket connection error'));
+          }
+        };
 
-    } catch (error) {
-      console.error('WebSocket connection failed:', error);
-      this.setStatus('error');
-      throw error;
-    }
+        socket.onclose = (event) => {
+          clearTimeout(timeout);
+          this.handleClose(event);
+          if (!hasOpened) {
+            reject(new Error(`WebSocket closed before ready: ${event.code}`));
+          }
+        };
+      } catch (error) {
+        console.error('WebSocket connection failed:', error);
+        this.setStatus('error');
+        throw error;
+      }
+    });
   }
 
-  // 断开连接
-  disconnect(): void {
-    if (this.socket) {
-      this.socket.disconnect();
-      this.socket = null;
-    }
-    
-    if (this.heartbeatInterval) {
-      clearInterval(this.heartbeatInterval);
-      this.heartbeatInterval = null;
-    }
-    
-    this.subscriptions.clear();
-    this.setStatus('disconnected');
+  // 处理连接成功
+  private handleOpen() {
+    console.log('WebSocket connected');
+    this.setStatus('connected');
+    this.reconnectAttempts = 0;
+    this.stats.lastConnected = new Date();
+    this.startHeartbeat();
+    this.resubscribeAll();
+  }
+
+  // 处理关闭事件
+  private handleClose(event: CloseEvent) {
+    console.log('WebSocket disconnected:', event.code, event.reason);
+    this.stopHeartbeat();
+    this.socket = null;
     this.stats.lastDisconnected = new Date();
-    
-    console.log('WebSocket disconnected');
+
+    if (this.manualDisconnect) {
+      this.setStatus('disconnected');
+      return;
+    }
+
+    this.scheduleReconnect();
   }
 
-  // 设置事件监听器
-  private setupEventListeners(): void {
-    if (!this.socket) return;
-
-    // 连接成功
-    this.socket.on('connect', () => {
-      console.log('WebSocket connected');
-      this.setStatus('connected');
-      this.reconnectAttempts = 0;
-      this.stats.lastConnected = new Date();
-      this.startHeartbeat();
-      
-      // 重新订阅之前的订阅
-      this.resubscribeAll();
-    });
-
-    // 连接断开
-    this.socket.on('disconnect', (reason) => {
-      console.log('WebSocket disconnected:', reason);
-      this.setStatus('disconnected');
-      this.stats.lastDisconnected = new Date();
-      
-      if (this.heartbeatInterval) {
-        clearInterval(this.heartbeatInterval);
-        this.heartbeatInterval = null;
-      }
-      
-      // 自动重连
-      if (reason !== 'io client disconnect') {
-        this.scheduleReconnect();
-      }
-    });
-
-    // 连接错误
-    this.socket.on('connect_error', (error) => {
-      console.error('WebSocket connection error:', error);
-      this.setStatus('error');
-      this.scheduleReconnect();
-    });
-
-    // 接收消息
-    this.socket.on('message', (message: WebSocketMessage) => {
-      this.handleMessage(message);
-    });
-
-    // 数据消息
-    this.socket.on('data', (data: any) => {
-      this.handleDataMessage(data);
-    });
-
-    // 错误消息
-    this.socket.on('error', (error: any) => {
-      console.error('WebSocket error:', error);
-      this.handleError(error);
-    });
-
-    // 确认消息
-    this.socket.on('ack', (ack: any) => {
-      console.log('WebSocket ack:', ack);
-    });
-
-    // 状态消息
-    this.socket.on('status', (status: any) => {
-      console.log('WebSocket status:', status);
+  // 处理错误
+  private handleError(error: any) {
+    this.setStatus('error');
+    const store = useAppStore.getState();
+    store.addNotification({
+      type: 'error',
+      title: 'WebSocket错误',
+      message: error?.message || 'WebSocket connection error',
     });
   }
 
   // 处理消息
-  private handleMessage(message: WebSocketMessage): void {
+  private handleIncomingMessage(rawMessage: any) {
     this.stats.messagesReceived++;
-    
-    switch (message.type) {
-      case 'data':
-        this.handleDataMessage(message.data);
-        break;
-      case 'error':
-        this.handleError(message.data);
-        break;
-      case 'heartbeat':
-        // 心跳响应，不需要特殊处理
-        break;
-      default:
-        console.log('Unknown message type:', message.type, message.data);
+
+    try {
+      const message: WebSocketMessage = typeof rawMessage === 'string' ? JSON.parse(rawMessage) : rawMessage;
+
+      switch (message.type) {
+        case 'data':
+          this.handleDataMessage(message.data);
+          break;
+        case 'error':
+          this.handleError(message.data);
+          break;
+        case 'status':
+          console.log('WebSocket status:', message.data);
+          break;
+        case 'ack':
+          console.log('WebSocket ack:', message.data);
+          break;
+        default:
+          break;
+      }
+    } catch (error) {
+      console.error('Failed to parse WebSocket message:', error);
     }
   }
 
   // 处理数据消息
-  private handleDataMessage(data: any): void {
+  private handleDataMessage(data: any) {
     try {
       const { subscription_type, payload } = data;
-      
+
       // 更新store中的数据
       this.updateStoreData(subscription_type, payload);
-      
+
       // 调用注册的处理器
       const handler = this.messageHandlers.get(subscription_type);
       if (handler) {
         handler(payload);
       }
-      
     } catch (error) {
       console.error('Error handling data message:', error);
     }
   }
 
   // 更新store数据
-  private updateStoreData(subscriptionType: string, payload: any): void {
+  private updateStoreData(subscriptionType: string, payload: any) {
     const store = useAppStore.getState();
-    
+
     switch (subscriptionType) {
       case 'market_data':
       case 'quotes':
-        // 更新市场数据
         if (payload.data && Array.isArray(payload.data)) {
           store.updateMarketData('indices', payload.data);
         }
         break;
-        
       case 'signals':
-        // 更新交易信号
-        // 这里可以添加信号处理逻辑
         break;
-        
       case 'news':
-        // 更新新闻数据
         store.addNotification({
           type: 'info',
           title: '市场新闻',
           message: payload.title || '收到新的市场新闻',
         });
         break;
-        
       case 'alerts':
-        // 系统告警
         store.addNotification({
           type: 'warning',
           title: '系统告警',
           message: payload.message || '收到系统告警',
         });
         break;
-        
       default:
-        console.log('Unknown subscription type:', subscriptionType);
+        break;
     }
-  }
-
-  // 处理错误
-  private handleError(error: any): void {
-    console.error('WebSocket error:', error);
-    
-    const store = useAppStore.getState();
-    store.addNotification({
-      type: 'error',
-      title: 'WebSocket错误',
-      message: error.error || error.message || '未知错误',
-    });
   }
 
   // 发送消息
   private sendMessage(message: WebSocketMessage): void {
-    if (!this.socket?.connected) {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
       console.warn('WebSocket not connected, cannot send message');
       return;
     }
-    
+
     try {
-      this.socket.emit('message', {
+      const payload = {
         ...message,
         timestamp: new Date().toISOString(),
-        message_id: `msg_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-      });
-      
+        message_id: message.message_id ?? `msg_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`,
+      };
+      this.socket.send(JSON.stringify(payload));
       this.stats.messagesSent++;
     } catch (error) {
       console.error('Error sending message:', error);
@@ -301,24 +284,22 @@ class WebSocketService {
   // 订阅数据
   subscribe(subscriptionType: string, filters?: Record<string, any>): string {
     const subscriptionId = `sub_${subscriptionType}_${Date.now()}`;
-    
+
     const config: SubscriptionConfig = {
       subscription_type: subscriptionType,
       filters,
     };
-    
+
     this.subscriptions.set(subscriptionId, config);
-    
-    // 发送订阅消息
+
     this.sendMessage({
       type: 'subscribe',
       data: config,
     });
-    
-    // 更新store
+
     const store = useAppStore.getState();
     store.addSubscription(subscriptionId);
-    
+
     console.log(`Subscribed to ${subscriptionType}:`, subscriptionId);
     return subscriptionId;
   }
@@ -330,19 +311,17 @@ class WebSocketService {
       console.warn('Subscription not found:', subscriptionId);
       return;
     }
-    
-    // 发送取消订阅消息
+
     this.sendMessage({
       type: 'unsubscribe',
       data: { subscription_id: subscriptionId },
     });
-    
+
     this.subscriptions.delete(subscriptionId);
-    
-    // 更新store
+
     const store = useAppStore.getState();
     store.removeSubscription(subscriptionId);
-    
+
     console.log(`Unsubscribed from:`, subscriptionId);
   }
 
@@ -354,47 +333,30 @@ class WebSocketService {
         data: config,
       });
     }
-    
+
     if (this.subscriptions.size > 0) {
       console.log(`Resubscribed to ${this.subscriptions.size} subscriptions`);
     }
   }
 
-  // 注册消息处理器
-  onMessage(subscriptionType: string, handler: (data: any) => void): void {
-    this.messageHandlers.set(subscriptionType, handler);
-  }
-
-  // 移除消息处理器
-  offMessage(subscriptionType: string): void {
-    this.messageHandlers.delete(subscriptionType);
-  }
-
-  // 发送心跳
-  private sendHeartbeat(): void {
-    this.sendMessage({
-      type: 'heartbeat',
-      data: {
-        client_time: new Date().toISOString(),
-      },
-    });
-  }
-
   // 启动心跳
   private startHeartbeat(): void {
-    if (this.heartbeatInterval) {
-      clearInterval(this.heartbeatInterval);
-    }
-    
-    this.heartbeatInterval = setInterval(() => {
-      this.sendHeartbeat();
-    }, 30000); // 30秒心跳
+    this.stopHeartbeat();
+
+    this.heartbeatTimer = setInterval(() => {
+      this.sendMessage({
+        type: 'heartbeat',
+        data: {
+          client_time: new Date().toISOString(),
+        },
+      });
+    }, HEARTBEAT_INTERVAL);
   }
 
   // 设置连接状态
   private setStatus(status: ConnectionStatus): void {
     this.status = status;
-    
+
     const store = useAppStore.getState();
     store.setWebSocketConnected(status === 'connected');
     store.setWebSocketReconnecting(status === 'reconnecting');
@@ -402,25 +364,44 @@ class WebSocketService {
 
   // 计划重连
   private scheduleReconnect(): void {
+    if (this.manualDisconnect) {
+      return;
+    }
+
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {
       console.error('Max reconnect attempts reached');
       this.setStatus('error');
       return;
     }
-    
+
     this.reconnectAttempts++;
     this.stats.reconnectCount++;
     this.setStatus('reconnecting');
-    
+
     const delay = this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
     console.log(`Scheduling reconnect attempt ${this.reconnectAttempts} in ${delay}ms`);
-    
-    setTimeout(() => {
-      this.connect().catch((error) => {
+
+    this.clearReconnectTimer();
+    this.reconnectTimer = setTimeout(() => {
+      this.connect(this.pendingToken).catch((error) => {
         console.error('Reconnect failed:', error);
         this.scheduleReconnect();
       });
     }, delay);
+  }
+
+  // 断开连接
+  disconnect(): void {
+    this.manualDisconnect = true;
+    this.clearReconnectTimer();
+    this.stopHeartbeat();
+
+    if (this.socket && this.socket.readyState !== WebSocket.CLOSED) {
+      this.socket.close(1000, 'Manual disconnect');
+    }
+
+    this.socket = null;
+    this.setStatus('disconnected');
   }
 
   // 获取连接状态
@@ -430,7 +411,7 @@ class WebSocketService {
 
   // 检查是否已连接
   isConnected(): boolean {
-    return this.socket?.connected || false;
+    return this.socket?.readyState === WebSocket.OPEN;
   }
 
   // 获取统计信息
@@ -454,12 +435,15 @@ class WebSocketService {
 
   // 更新URL
   updateUrl(url: string): void {
-    if (this.url !== url) {
-      this.url = url;
-      if (this.isConnected()) {
-        this.disconnect();
-        this.connect().catch(console.error);
-      }
+    if (this.url === url) {
+      return;
+    }
+
+    this.url = url;
+
+    if (this.isConnected()) {
+      this.disconnect();
+      this.connect(this.pendingToken).catch(console.error);
     }
   }
 }

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+  readonly VITE_WS_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- centralize configurable API and WebSocket endpoints with defaults that match the backend services
- replace the socket.io client wrapper with a native WebSocket implementation that supports reconnection and resubscription
- guard layout notifications against undefined state and update hooks/components to consume the shared WebSocket URL

## Testing
- npm run build *(fails: existing TypeScript errors in unrelated chat/system hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6ed57d048325a0cabf532c85945e