### PR TITLE
feat(web): add qwen chat integration with knowledge graph controls

### DIFF
--- a/apps/web/src/components/Chat/ChatModelSelector.tsx
+++ b/apps/web/src/components/Chat/ChatModelSelector.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { clsx } from 'clsx';
+import { Activity, CheckCircle2, AlertCircle, RefreshCw, Server, TestTube2 } from 'lucide-react';
+import type { LLMModelOption } from '../../store';
+import type { ModelTestResult } from '../../hooks/useChatService';
+
+interface ChatModelSelectorProps {
+  models: LLMModelOption[];
+  currentModel: string;
+  onChange: (model: string) => void;
+  onTestConnection?: (provider: string) => Promise<ModelTestResult>;
+  tests?: Record<string, ModelTestResult>;
+  isLoading?: boolean;
+}
+
+const providerLabel: Record<string, string> = {
+  openai: 'OpenAI',
+  qwen: '通义千问',
+  anthropic: 'Claude',
+  gemini: 'Google Gemini',
+};
+
+const statusStyles: Record<string, string> = {
+  online: 'bg-green-100 text-green-700 border-green-200',
+  degraded: 'bg-yellow-100 text-yellow-700 border-yellow-200',
+  offline: 'bg-red-100 text-red-700 border-red-200',
+};
+
+export const ChatModelSelector: React.FC<ChatModelSelectorProps> = ({
+  models,
+  currentModel,
+  onChange,
+  onTestConnection,
+  tests,
+  isLoading,
+}) => {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900">模型选择</h3>
+          <p className="text-xs text-gray-500">支持通义千问 QWEN 与多家厂商模型</p>
+        </div>
+        {isLoading && (
+          <div className="flex items-center space-x-1 text-xs text-gray-500">
+            <RefreshCw className="w-3 h-3 animate-spin" />
+            <span>同步模型列表</span>
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        {models.map((model) => {
+          const isActive = model.model === currentModel || model.id === currentModel;
+          const status = model.status ?? 'online';
+          const test = tests?.[model.provider];
+
+          return (
+            <div
+              key={model.id}
+              className={clsx(
+                'border rounded-lg p-3 transition-all duration-200 bg-white shadow-sm',
+                isActive ? 'border-primary-300 ring-2 ring-primary-100' : 'border-gray-200 hover:border-primary-200'
+              )}
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex-1">
+                  <div className="flex items-center space-x-2">
+                    <Server className={clsx('w-4 h-4', isActive ? 'text-primary-600' : 'text-gray-400')} />
+                    <button
+                      type="button"
+                      onClick={() => onChange(model.model)}
+                      className={clsx(
+                        'text-sm font-medium transition-colors',
+                        isActive ? 'text-primary-700' : 'text-gray-800 hover:text-primary-600'
+                      )}
+                    >
+                      {model.name}
+                    </button>
+                    <span className="text-xs text-gray-500">
+                      {providerLabel[model.provider] ?? model.provider}
+                    </span>
+                  </div>
+
+                  <p className="mt-1 text-xs text-gray-500 leading-snug">
+                    {model.description ?? '无详细描述'}
+                  </p>
+
+                  <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
+                    <span
+                      className={clsx(
+                        'inline-flex items-center px-2 py-0.5 rounded-full border',
+                        statusStyles[status] ?? statusStyles.online
+                      )}
+                    >
+                      <Activity className="w-3 h-3 mr-1" />
+                      {status === 'online'
+                        ? '在线'
+                        : status === 'degraded'
+                        ? '性能下降'
+                        : '离线'}
+                    </span>
+                    <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">
+                      上下文 {model.context}
+                    </span>
+                    {model.capabilities?.map((cap) => (
+                      <span
+                        key={cap}
+                        className="inline-flex items-center px-2 py-0.5 rounded-full bg-primary-50 text-primary-600"
+                      >
+                        {cap}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                {onTestConnection && (
+                  <div className="ml-4 flex flex-col items-end space-y-1">
+                    <button
+                      type="button"
+                      onClick={() => onTestConnection(model.provider)}
+                      className="inline-flex items-center px-2 py-1 text-xs font-medium text-primary-600 border border-primary-200 rounded hover:bg-primary-50"
+                    >
+                      <TestTube2 className="w-3 h-3 mr-1" /> 测试连接
+                    </button>
+                    {test && (
+                      <div
+                        className={clsx(
+                          'inline-flex items-center px-2 py-0.5 text-[11px] rounded-full',
+                          test.success ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+                        )}
+                      >
+                        {test.success ? <CheckCircle2 className="w-3 h-3 mr-1" /> : <AlertCircle className="w-3 h-3 mr-1" />}
+                        {test.success ? '连接正常' : '连接失败'}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ChatModelSelector;

--- a/apps/web/src/components/Chat/EnhancedChatInterface.tsx
+++ b/apps/web/src/components/Chat/EnhancedChatInterface.tsx
@@ -1,715 +1,443 @@
 // 增强的LLM聊天界面
-// 支持Agent工具调用可视化、状态监控和高级交互功能
+// 引入 QWEN 模型联动与知识图谱控制
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { clsx } from 'clsx';
 import {
-  Send,
-  Mic,
-  MicOff,
-  Paperclip,
-  MoreVertical,
-  Copy,
-  RefreshCw,
-  Trash2,
-  Download,
-  Settings,
   Bot,
   User,
-  Zap,
-  Clock,
-  CheckCircle,
-  XCircle,
-  AlertCircle,
-  Eye,
-  EyeOff,
-  Play,
-  Pause,
+  Send,
+  Paperclip,
+  Mic,
   Square,
-  ChevronDown,
-  ChevronRight,
-  Code,
-  BarChart3,
-  TrendingUp,
-  Database,
-  Search,
-  FileText,
-  Brain,
-  Target,
-  Layers,
-  Activity,
+  Settings,
+  Trash2,
+  Loader2,
+  Sparkles,
+  Workflow,
+  ShieldCheck,
+  Copy,
 } from 'lucide-react';
-import { useChat, useChatActions } from '../../store';
-import apiService from '../../services/api';
-
-// 消息类型
-interface Message {
-  id: string;
-  type: 'user' | 'assistant' | 'system';
-  content: string;
-  timestamp: Date;
-  metadata?: {
-    model?: string;
-    tokens?: number;
-    cost?: number;
-    tools_used?: ToolCall[];
-    agent_status?: AgentStatus;
-    execution_time?: number;
-    confidence?: number;
-  };
-  status?: 'sending' | 'sent' | 'error' | 'streaming';
-  error?: string;
-}
-
-// 工具调用
-interface ToolCall {
-  id: string;
-  name: string;
-  arguments: Record<string, any>;
-  result?: any;
-  status: 'pending' | 'running' | 'completed' | 'failed';
-  execution_time?: number;
-  error?: string;
-}
-
-// Agent状态
-interface AgentStatus {
-  current_task?: string;
-  progress?: number;
-  stage?: string;
-  tools_available?: string[];
-  active_tools?: string[];
-  reasoning?: string;
-  next_actions?: string[];
-}
-
-// 模型选项
-const MODELS = [
-  { id: 'gpt-4', name: 'GPT-4', provider: 'openai', context: '8K' },
-  { id: 'gpt-4-turbo', name: 'GPT-4 Turbo', provider: 'openai', context: '128K' },
-  { id: 'gpt-3.5-turbo', name: 'GPT-3.5 Turbo', provider: 'openai', context: '16K' },
-  { id: 'claude-3-opus', name: 'Claude 3 Opus', provider: 'anthropic', context: '200K' },
-  { id: 'claude-3-sonnet', name: 'Claude 3 Sonnet', provider: 'anthropic', context: '200K' },
-  { id: 'gemini-pro', name: 'Gemini Pro', provider: 'google', context: '32K' },
-];
-
-// 工具图标映射
-const TOOL_ICONS: Record<string, React.ComponentType<any>> = {
-  market_data: TrendingUp,
-  stock_analysis: BarChart3,
-  strategy_backtest: Activity,
-  portfolio_optimization: Target,
-  knowledge_graph: Layers,
-  factor_analysis: Database,
-  report_generation: FileText,
-  web_search: Search,
-  code_execution: Code,
-  default: Zap,
-};
+import { format } from 'date-fns';
+import { zhCN } from 'date-fns/locale';
+import ChatModelSelector from './ChatModelSelector';
+import KnowledgeGraphPanel from '../KnowledgeGraph/KnowledgeGraphPanel';
+import { useChatService } from '../../hooks/useChatService';
+import { useKnowledgeGraphService } from '../../hooks/useKnowledgeGraph';
+import type { ChatMessage } from '../../store';
 
 interface EnhancedChatInterfaceProps {
   className?: string;
 }
 
-export const EnhancedChatInterface: React.FC<EnhancedChatInterfaceProps> = ({ className }) => {
-  const { messages, currentModel, isLoading } = useChat();
-  const { sendMessage, setModel, clearMessages } = useChatActions();
-  
-  const [input, setInput] = useState('');
-  const [isRecording, setIsRecording] = useState(false);
-  const [showSettings, setShowSettings] = useState(false);
-  const [showToolDetails, setShowToolDetails] = useState<Record<string, boolean>>({});
-  const [agentMode, setAgentMode] = useState(true);
-  const [streamingMessage, setStreamingMessage] = useState<string>('');
-  const [currentAgentStatus, setCurrentAgentStatus] = useState<AgentStatus | null>(null);
-  
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
+interface MessageBubbleProps {
+  message: ChatMessage;
+  onCopy: (text: string) => void;
+}
 
-  // 自动滚动到底部
-  const scrollToBottom = useCallback(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, []);
+const MessageBubble: React.FC<MessageBubbleProps> = ({ message, onCopy }) => {
+  const isUser = message.type === 'user';
+  const timestamp = useMemo(() => {
+    try {
+      return format(new Date(message.timestamp), 'HH:mm:ss', { locale: zhCN });
+    } catch {
+      return '';
+    }
+  }, [message.timestamp]);
+
+  return (
+    <div className={clsx('flex w-full', isUser ? 'justify-end' : 'justify-start')}>
+      <div
+        className={clsx(
+          'max-w-2xl rounded-2xl px-4 py-3 shadow-sm border space-y-2 transition-all duration-150',
+          isUser
+            ? 'bg-primary-600 text-white border-primary-600'
+            : 'bg-white text-gray-900 border-gray-200'
+        )}
+      >
+        <div className="flex items-center justify-between space-x-3 text-xs">
+          <div className="flex items-center space-x-2">
+            {isUser ? <User className="w-4 h-4" /> : <Bot className="w-4 h-4" />}
+            <span>{timestamp}</span>
+            {!isUser && message.metadata?.model && (
+              <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-primary-50 text-primary-700">
+                {message.metadata.provider ?? 'model'} · {message.metadata.model}
+              </span>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => onCopy(message.content)}
+            className={clsx(
+              'inline-flex items-center space-x-1',
+              isUser ? 'text-primary-50 hover:text-white' : 'text-gray-400 hover:text-gray-600'
+            )}
+          >
+            <Copy className="w-3 h-3" />
+            <span>复制</span>
+          </button>
+        </div>
+
+        <div className="whitespace-pre-wrap text-sm leading-relaxed">{message.content}</div>
+
+        {!isUser && (
+          <div className="flex flex-wrap items-center gap-2 text-[11px] text-gray-500">
+            {typeof message.metadata?.tokens === 'number' && (
+              <span>Tokens: {message.metadata.tokens}</span>
+            )}
+            {typeof message.metadata?.execution_time === 'number' && (
+              <span>耗时: {Math.round(message.metadata.execution_time)}ms</span>
+            )}
+            {typeof message.metadata?.confidence === 'number' && (
+              <span>置信度: {Math.round(message.metadata.confidence * 100)}%</span>
+            )}
+            {Array.isArray(message.metadata?.tools_used) && message.metadata?.tools_used.length > 0 && (
+              <span>工具: {message.metadata.tools_used.join(', ')}</span>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const EnhancedChatInterface: React.FC<EnhancedChatInterfaceProps> = ({ className }) => {
+  const [input, setInput] = useState('');
+  const [showSettings, setShowSettings] = useState(false);
+  const [agentMode, setAgentMode] = useState(true);
+  const [isRecording, setIsRecording] = useState(false);
+  const [isSyncingModels, setIsSyncingModels] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const {
+    chatState,
+    currentModelOption,
+    modelTests,
+    loadAvailableModels,
+    testModelConnection,
+    sendAgentMessage,
+    clearMessages,
+    setCurrentModel,
+  } = useChatService();
+  const knowledgeGraphService = useKnowledgeGraphService();
 
   useEffect(() => {
-    scrollToBottom();
-  }, [messages, streamingMessage, scrollToBottom]);
+    let isMounted = true;
+    setIsSyncingModels(true);
+    loadAvailableModels()
+      .catch((error) => console.error('Load models error:', error))
+      .finally(() => {
+        if (isMounted) {
+          setIsSyncingModels(false);
+        }
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, [loadAvailableModels]);
 
-  // 发送消息
-  const handleSendMessage = async () => {
-    if (!input.trim() || isLoading) return;
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [chatState.messages]);
 
-    const userMessage = input.trim();
-    setInput('');
-    
+  const handleSend = async () => {
+    if (!input.trim() || chatState.isLoading) return;
     try {
-      if (agentMode) {
-        // Agent模式：支持工具调用
-        await sendAgentMessage(userMessage);
-      } else {
-        // 普通模式：直接LLM对话
-        await sendMessage(userMessage);
-      }
+      const knowledgePayload = knowledgeGraphService.getKnowledgeGraphContext();
+      await sendAgentMessage(input, {
+        agentMode,
+        knowledgeGraph: knowledgePayload,
+      });
+      setInput('');
     } catch (error) {
       console.error('Failed to send message:', error);
     }
   };
 
-  // 发送Agent消息
-  const sendAgentMessage = async (content: string) => {
-    try {
-      const response = await apiService.sendAgentMessage({
-        message: content,
-        model: currentModel,
-        enable_tools: true,
-        context: messages.slice(-10).map(msg => ({
-          role: msg.type === 'user' ? 'user' : 'assistant',
-          content: msg.content,
-        })),
-      });
-
-      // 处理流式响应
-      if (response.stream) {
-        handleStreamingResponse(response.stream);
-      } else {
-        // 处理完整响应
-        handleCompleteResponse(response);
-      }
-    } catch (error) {
-      console.error('Agent message error:', error);
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      handleSend();
     }
   };
 
-  // 处理流式响应
-  const handleStreamingResponse = async (stream: ReadableStream) => {
-    const reader = stream.getReader();
-    let accumulatedContent = '';
-    let currentTools: ToolCall[] = [];
-    
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        
-        const chunk = new TextDecoder().decode(value);
-        const lines = chunk.split('\n').filter(line => line.trim());
-        
-        for (const line of lines) {
-          if (line.startsWith('data: ')) {
-            try {
-              const data = JSON.parse(line.slice(6));
-              
-              if (data.type === 'content') {
-                accumulatedContent += data.content;
-                setStreamingMessage(accumulatedContent);
-              } else if (data.type === 'tool_call') {
-                currentTools.push(data.tool);
-                setCurrentAgentStatus(prev => ({
-                  ...prev,
-                  active_tools: currentTools.map(t => t.name),
-                  current_task: data.tool.name,
-                }));
-              } else if (data.type === 'agent_status') {
-                setCurrentAgentStatus(data.status);
-              }
-            } catch (e) {
-              console.warn('Failed to parse streaming data:', e);
-            }
-          }
-        }
-      }
-    } finally {
-      reader.releaseLock();
-      setStreamingMessage('');
-      setCurrentAgentStatus(null);
-    }
-  };
-
-  // 处理完整响应
-  const handleCompleteResponse = (response: any) => {
-    // 添加助手消息到聊天记录
-    const assistantMessage: Message = {
-      id: Date.now().toString(),
-      type: 'assistant',
-      content: response.content,
-      timestamp: new Date(),
-      metadata: {
-        model: response.model,
-        tokens: response.usage?.total_tokens,
-        cost: response.cost,
-        tools_used: response.tools_used,
-        execution_time: response.execution_time,
-        confidence: response.confidence,
-      },
-      status: 'sent',
-    };
-    
-    // 这里应该调用store的action来添加消息
-    console.log('Complete response:', assistantMessage);
-  };
-
-  // 键盘事件处理
-  const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSendMessage();
-    }
-  };
-
-  // 复制消息
-  const handleCopyMessage = (content: string) => {
-    navigator.clipboard.writeText(content);
-    // 显示复制成功提示
-  };
-
-  // 重新生成回复
-  const handleRegenerateResponse = (messageId: string) => {
-    // 找到用户消息并重新发送
-    const messageIndex = messages.findIndex(m => m.id === messageId);
-    if (messageIndex > 0) {
-      const userMessage = messages[messageIndex - 1];
-      if (userMessage.type === 'user') {
-        handleSendMessage();
-      }
-    }
-  };
-
-  // 语音输入
   const handleVoiceInput = () => {
     if (isRecording) {
       setIsRecording(false);
-      // 停止录音并处理语音识别
     } else {
       setIsRecording(true);
-      // 开始录音
+      setTimeout(() => {
+        setIsRecording(false);
+        setInput((value) => `${value}${value ? '\n' : ''}（语音转写示例）`);
+      }, 2500);
     }
   };
 
-  // 文件上传
   const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
     if (files && files.length > 0) {
-      // 处理文件上传
-      console.log('Files uploaded:', files);
+      console.info('Selected files for upload:', Array.from(files).map((file) => file.name));
     }
   };
 
-  // 渲染工具调用
-  const renderToolCall = (tool: ToolCall, messageId: string) => {
-    const Icon = TOOL_ICONS[tool.name] || TOOL_ICONS.default;
-    const isExpanded = showToolDetails[`${messageId}-${tool.id}`];
-    
-    return (
-      <div key={tool.id} className="border border-gray-200 rounded-lg p-3 mb-2">
-        <div 
-          className="flex items-center justify-between cursor-pointer"
-          onClick={() => setShowToolDetails({
-            ...showToolDetails,
-            [`${messageId}-${tool.id}`]: !isExpanded
-          })}
-        >
-          <div className="flex items-center space-x-2">
-            <Icon className="w-4 h-4 text-blue-600" />
-            <span className="text-sm font-medium text-gray-900">{tool.name}</span>
-            <span className={clsx(
-              'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium',
-              tool.status === 'completed' ? 'bg-green-100 text-green-800' :
-              tool.status === 'running' ? 'bg-blue-100 text-blue-800' :
-              tool.status === 'failed' ? 'bg-red-100 text-red-800' :
-              'bg-gray-100 text-gray-800'
-            )}>
-              {tool.status === 'completed' && <CheckCircle className="w-3 h-3 mr-1" />}
-              {tool.status === 'running' && <RefreshCw className="w-3 h-3 mr-1 animate-spin" />}
-              {tool.status === 'failed' && <XCircle className="w-3 h-3 mr-1" />}
-              {tool.status === 'pending' && <Clock className="w-3 h-3 mr-1" />}
-              {tool.status}
-            </span>
-            {tool.execution_time && (
-              <span className="text-xs text-gray-500">
-                {tool.execution_time}ms
-              </span>
-            )}
-          </div>
-          
-          {isExpanded ? (
-            <ChevronDown className="w-4 h-4 text-gray-400" />
-          ) : (
-            <ChevronRight className="w-4 h-4 text-gray-400" />
-          )}
-        </div>
-        
-        {isExpanded && (
-          <div className="mt-3 space-y-2">
-            {Object.keys(tool.arguments).length > 0 && (
-              <div>
-                <p className="text-xs font-medium text-gray-700 mb-1">参数:</p>
-                <pre className="text-xs bg-gray-50 p-2 rounded overflow-x-auto">
-                  {JSON.stringify(tool.arguments, null, 2)}
-                </pre>
-              </div>
-            )}
-            
-            {tool.result && (
-              <div>
-                <p className="text-xs font-medium text-gray-700 mb-1">结果:</p>
-                <pre className="text-xs bg-gray-50 p-2 rounded overflow-x-auto max-h-32">
-                  {typeof tool.result === 'string' ? tool.result : JSON.stringify(tool.result, null, 2)}
-                </pre>
-              </div>
-            )}
-            
-            {tool.error && (
-              <div>
-                <p className="text-xs font-medium text-red-700 mb-1">错误:</p>
-                <p className="text-xs text-red-600 bg-red-50 p-2 rounded">{tool.error}</p>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-    );
+  const handleCopy = (content: string) => {
+    navigator.clipboard.writeText(content).catch((error) => console.error('Copy failed:', error));
   };
 
-  // 渲染Agent状态
-  const renderAgentStatus = (status: AgentStatus) => (
-    <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 mb-4">
-      <div className="flex items-center space-x-2 mb-2">
-        <Bot className="w-4 h-4 text-blue-600" />
-        <span className="text-sm font-medium text-blue-900">Agent状态</span>
-      </div>
-      
-      {status.current_task && (
-        <p className="text-sm text-blue-800 mb-1">
-          当前任务: {status.current_task}
-        </p>
-      )}
-      
-      {status.progress !== undefined && (
-        <div className="mb-2">
-          <div className="flex justify-between text-xs text-blue-700 mb-1">
-            <span>进度</span>
-            <span>{Math.round(status.progress * 100)}%</span>
-          </div>
-          <div className="w-full bg-blue-200 rounded-full h-1.5">
-            <div 
-              className="bg-blue-600 h-1.5 rounded-full transition-all duration-300"
-              style={{ width: `${status.progress * 100}%` }}
-            />
-          </div>
-        </div>
-      )}
-      
-      {status.reasoning && (
-        <p className="text-xs text-blue-700 mb-2">
-          推理: {status.reasoning}
-        </p>
-      )}
-      
-      {status.active_tools && status.active_tools.length > 0 && (
-        <div className="flex flex-wrap gap-1">
-          {status.active_tools.map((tool, index) => (
-            <span key={index} className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-blue-100 text-blue-800">
-              <Zap className="w-3 h-3 mr-1" />
-              {tool}
-            </span>
-          ))}
-        </div>
-      )}
-    </div>
-  );
+  const modelSummary = useMemo(() => {
+    if (!currentModelOption) {
+      return chatState.currentModel;
+    }
+    return `${currentModelOption.name} · ${currentModelOption.provider.toUpperCase()}`;
+  }, [chatState.currentModel, currentModelOption]);
 
-  // 渲染消息
-  const renderMessage = (message: Message) => {
-    const isUser = message.type === 'user';
-    
-    return (
-      <div key={message.id} className={clsx(
-        'flex mb-4',
-        isUser ? 'justify-end' : 'justify-start'
-      )}>
-        <div className={clsx(
-          'max-w-3xl rounded-lg px-4 py-3',
-          isUser 
-            ? 'bg-blue-600 text-white'
-            : 'bg-gray-100 text-gray-900'
-        )}>
-          {/* 消息头部 */}
-          <div className="flex items-center justify-between mb-2">
-            <div className="flex items-center space-x-2">
-              {isUser ? (
-                <User className="w-4 h-4" />
-              ) : (
-                <Bot className="w-4 h-4" />
-              )}
-              <span className="text-sm font-medium">
-                {isUser ? '用户' : (message.metadata?.model || 'Assistant')}
-              </span>
-              <span className="text-xs opacity-70">
-                {message.timestamp.toLocaleTimeString()}
-              </span>
-            </div>
-            
-            <div className="flex items-center space-x-1">
-              <button
-                onClick={() => handleCopyMessage(message.content)}
-                className={clsx(
-                  'p-1 rounded hover:bg-opacity-20',
-                  isUser ? 'hover:bg-white' : 'hover:bg-gray-300'
-                )}
-              >
-                <Copy className="w-3 h-3" />
-              </button>
-              
-              {!isUser && (
-                <button
-                  onClick={() => handleRegenerateResponse(message.id)}
-                  className="p-1 rounded hover:bg-gray-300 hover:bg-opacity-20"
-                >
-                  <RefreshCw className="w-3 h-3" />
-                </button>
-              )}
-            </div>
-          </div>
-          
-          {/* 消息内容 */}
-          <div className="prose prose-sm max-w-none">
-            <p className="whitespace-pre-wrap">{message.content}</p>
-          </div>
-          
-          {/* 工具调用 */}
-          {message.metadata?.tools_used && message.metadata.tools_used.length > 0 && (
-            <div className="mt-3">
-              <p className="text-xs font-medium mb-2 opacity-70">工具调用:</p>
-              {message.metadata.tools_used.map(tool => 
-                renderToolCall(tool, message.id)
-              )}
-            </div>
-          )}
-          
-          {/* 消息元数据 */}
-          {message.metadata && (
-            <div className="mt-2 pt-2 border-t border-opacity-20 border-gray-300">
-              <div className="flex items-center space-x-4 text-xs opacity-70">
-                {message.metadata.tokens && (
-                  <span>令牌: {message.metadata.tokens}</span>
-                )}
-                {message.metadata.cost && (
-                  <span>成本: ${message.metadata.cost.toFixed(4)}</span>
-                )}
-                {message.metadata.execution_time && (
-                  <span>耗时: {message.metadata.execution_time}ms</span>
-                )}
-                {message.metadata.confidence && (
-                  <span>置信度: {Math.round(message.metadata.confidence * 100)}%</span>
-                )}
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-    );
-  };
+  const agentModeLabel = agentMode ? 'Agent编排模式' : '纯模型对话';
 
   return (
-    <div className={clsx('flex flex-col h-full', className)}>
-      {/* 聊天头部 */}
-      <div className="flex items-center justify-between p-4 border-b border-gray-200">
-        <div className="flex items-center space-x-3">
-          <div className="flex items-center space-x-2">
-            <Bot className="w-5 h-5 text-blue-600" />
-            <h2 className="text-lg font-semibold text-gray-900">
-              {agentMode ? 'Agent助手' : 'LLM对话'}
-            </h2>
-          </div>
-          
-          <div className="flex items-center space-x-2">
-            <button
-              onClick={() => setAgentMode(!agentMode)}
-              className={clsx(
-                'px-3 py-1 rounded-full text-sm font-medium transition-colors',
-                agentMode
-                  ? 'bg-blue-100 text-blue-700'
-                  : 'bg-gray-100 text-gray-700'
-              )}
-            >
-              {agentMode ? 'Agent模式' : '对话模式'}
-            </button>
-            
-            <select
-              value={currentModel}
-              onChange={(e) => setModel(e.target.value)}
-              className="text-sm border border-gray-300 rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-blue-500"
-            >
-              {MODELS.map(model => (
-                <option key={model.id} value={model.id}>
-                  {model.name} ({model.context})
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-        
-        <div className="flex items-center space-x-2">
-          <button
-            onClick={() => setShowSettings(!showSettings)}
-            className="p-2 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100"
-          >
-            <Settings className="w-4 h-4" />
-          </button>
-          
-          <button
-            onClick={clearMessages}
-            className="p-2 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100"
-          >
-            <Trash2 className="w-4 h-4" />
-          </button>
-        </div>
-      </div>
+    <div className={clsx('h-full', className)}>
+      <div className="grid h-full gap-4 xl:grid-cols-[minmax(0,2.15fr)_minmax(320px,1fr)]">
+        <div className="flex flex-col h-full bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+          <header className="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <div className="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center">
+                <Bot className="w-5 h-5 text-primary-600" />
+              </div>
+              <div>
+                <h2 className="text-base font-semibold text-gray-900">AI 智能投研助手</h2>
+                <div className="flex items-center space-x-2 text-xs text-gray-500">
+                  <span>{modelSummary}</span>
+                  <span>•</span>
+                  <button
+                    type="button"
+                    onClick={() => setAgentMode((prev) => !prev)}
+                    className={clsx(
+                      'inline-flex items-center px-2 py-0.5 rounded-full border transition-colors',
+                      agentMode
+                        ? 'bg-primary-100 border-primary-200 text-primary-700'
+                        : 'bg-gray-100 border-gray-200 text-gray-600'
+                    )}
+                  >
+                    <Workflow className="w-3 h-3 mr-1" />
+                    {agentModeLabel}
+                  </button>
+                  <span>•</span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      knowledgeGraphService.toggleKnowledgeGraph(!knowledgeGraphService.knowledgeGraph.enabled)
+                    }
+                    className={clsx(
+                      'inline-flex items-center px-2 py-0.5 rounded-full border transition-colors',
+                      knowledgeGraphService.knowledgeGraph.enabled
+                        ? 'bg-emerald-100 border-emerald-200 text-emerald-700'
+                        : 'bg-gray-100 border-gray-200 text-gray-600'
+                    )}
+                  >
+                    <Sparkles className="w-3 h-3 mr-1" />
+                    {knowledgeGraphService.knowledgeGraph.enabled ? '知识图谱已联动' : '知识图谱关闭'}
+                  </button>
+                </div>
+              </div>
+            </div>
 
-      {/* 聊天消息区域 */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
-        {messages.length === 0 ? (
-          <div className="text-center py-12">
-            <Bot className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-            <h3 className="text-lg font-medium text-gray-900 mb-2">
-              {agentMode ? '智能Agent助手' : 'LLM对话助手'}
-            </h3>
-            <p className="text-gray-500 mb-4">
-              {agentMode 
-                ? '我可以帮您分析市场、制定策略、执行量化研究任务'
-                : '开始与AI助手对话，获取投资建议和分析'
-              }
-            </p>
-            
-            {agentMode && (
-              <div className="grid grid-cols-2 gap-3 max-w-md mx-auto">
-                {[
-                  { icon: TrendingUp, text: '市场分析' },
-                  { icon: BarChart3, text: '股票研究' },
-                  { icon: Target, text: '策略优化' },
-                  { icon: FileText, text: '报告生成' },
-                ].map((item, index) => {
-                  const Icon = item.icon;
-                  return (
+            <div className="flex items-center space-x-2">
+              <button
+                type="button"
+                onClick={() => setShowSettings((prev) => !prev)}
+                className="p-2 rounded-lg text-gray-500 hover:text-gray-700 hover:bg-white"
+                title="聊天设置"
+              >
+                <Settings className="w-5 h-5" />
+              </button>
+              <button
+                type="button"
+                onClick={clearMessages}
+                className="p-2 rounded-lg text-gray-500 hover:text-gray-700 hover:bg-white"
+                title="清空对话"
+              >
+                <Trash2 className="w-5 h-5" />
+              </button>
+            </div>
+          </header>
+
+          {showSettings && (
+            <div className="px-4 py-4 border-b border-gray-200 bg-white space-y-4">
+              <ChatModelSelector
+                models={chatState.availableModels}
+                currentModel={chatState.currentModel}
+                onChange={setCurrentModel}
+                onTestConnection={testModelConnection}
+                tests={modelTests}
+                isLoading={isSyncingModels}
+              />
+
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium text-gray-700">Agent编排模式</p>
+                  <p className="text-xs text-gray-500">
+                    开启后支持任务拆解、工具调用与流程自动执行
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setAgentMode((prev) => !prev)}
+                  className={clsx(
+                    'inline-flex items-center px-3 py-1 rounded-full border text-sm transition-colors',
+                    agentMode
+                      ? 'bg-primary-600 text-white border-primary-600'
+                      : 'bg-gray-100 text-gray-600 border-gray-200'
+                  )}
+                >
+                  <Workflow className="w-4 h-4 mr-1" />
+                  {agentMode ? '已开启' : '已关闭'}
+                </button>
+              </div>
+
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium text-gray-700">知识图谱辅助</p>
+                  <p className="text-xs text-gray-500">同步实体与关系上下文，增强 QWEN 推理能力</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() =>
+                    knowledgeGraphService.toggleKnowledgeGraph(!knowledgeGraphService.knowledgeGraph.enabled)
+                  }
+                  className={clsx(
+                    'inline-flex items-center px-3 py-1 rounded-full border text-sm transition-colors',
+                    knowledgeGraphService.knowledgeGraph.enabled
+                      ? 'bg-emerald-600 text-white border-emerald-600'
+                      : 'bg-gray-100 text-gray-600 border-gray-200'
+                  )}
+                >
+                  <Sparkles className="w-4 h-4 mr-1" />
+                  {knowledgeGraphService.knowledgeGraph.enabled ? '已开启' : '已关闭'}
+                </button>
+              </div>
+
+              <div className="xl:hidden">
+                <KnowledgeGraphPanel />
+              </div>
+            </div>
+          )}
+
+          <main className="flex-1 overflow-y-auto bg-gray-50 px-4 py-6 space-y-4">
+            {chatState.messages.length === 0 ? (
+              <div className="flex flex-col items-center justify-center h-full text-center space-y-4">
+                <div className="w-16 h-16 rounded-full bg-primary-100 flex items-center justify-center">
+                  <Bot className="w-7 h-7 text-primary-600" />
+                </div>
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 mb-2">欢迎体验 QWEN 驱动的智能投研助手</h3>
+                  <p className="text-sm text-gray-600 max-w-md">
+                    连接通义千问与知识图谱，自动生成行情洞察、策略建议与风险提示。
+                  </p>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3 max-w-2xl text-left">
+                  {[
+                    '分析当前市场趋势并列出关键风险',
+                    '结合知识图谱推理新能源车产业链的投资机会',
+                    '请给出两条适合稳健型投资者的资产配置策略',
+                    '总结美股科技龙头最新财报亮点和潜在风险',
+                  ].map((suggestion) => (
                     <button
-                      key={index}
-                      onClick={() => setInput(item.text)}
-                      className="flex items-center space-x-2 p-3 text-left border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+                      key={suggestion}
+                      type="button"
+                      onClick={() => setInput(suggestion)}
+                      className="p-3 bg-white border border-gray-200 rounded-lg hover:border-primary-200 hover:bg-primary-50/50 transition-colors"
                     >
-                      <Icon className="w-4 h-4 text-blue-600" />
-                      <span className="text-sm text-gray-700">{item.text}</span>
+                      <div className="flex items-start space-x-2">
+                        <ShieldCheck className="w-4 h-4 text-primary-500 mt-0.5" />
+                        <span className="text-sm text-gray-700">{suggestion}</span>
+                      </div>
                     </button>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-        ) : (
-          <>
-            {messages.map(renderMessage)}
-            
-            {/* 当前Agent状态 */}
-            {currentAgentStatus && renderAgentStatus(currentAgentStatus)}
-            
-            {/* 流式消息 */}
-            {streamingMessage && (
-              <div className="flex justify-start mb-4">
-                <div className="max-w-3xl bg-gray-100 text-gray-900 rounded-lg px-4 py-3">
-                  <div className="flex items-center space-x-2 mb-2">
-                    <Bot className="w-4 h-4" />
-                    <span className="text-sm font-medium">Assistant</span>
-                    <RefreshCw className="w-3 h-3 animate-spin" />
-                  </div>
-                  <div className="prose prose-sm max-w-none">
-                    <p className="whitespace-pre-wrap">{streamingMessage}</p>
-                  </div>
+                  ))}
                 </div>
               </div>
+            ) : (
+              chatState.messages.map((message) => (
+                <MessageBubble key={message.id} message={message} onCopy={handleCopy} />
+              ))
             )}
-            
-            {/* 加载指示器 */}
-            {isLoading && !streamingMessage && (
-              <div className="flex justify-start mb-4">
-                <div className="bg-gray-100 rounded-lg px-4 py-3">
-                  <div className="flex items-center space-x-2">
-                    <RefreshCw className="w-4 h-4 animate-spin" />
-                    <span className="text-sm text-gray-600">正在思考...</span>
-                  </div>
-                </div>
-              </div>
-            )}
-          </>
-        )}
-        
-        <div ref={messagesEndRef} />
-      </div>
 
-      {/* 输入区域 */}
-      <div className="border-t border-gray-200 p-4">
-        <div className="flex items-end space-x-3">
-          <div className="flex-1">
-            <textarea
-              ref={inputRef}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyPress={handleKeyPress}
-              placeholder={agentMode ? "描述您的投研需求，我将为您制定执行方案..." : "输入消息..."}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              rows={input.split('\n').length}
-              disabled={isLoading}
-            />
-          </div>
-          
-          <div className="flex items-center space-x-2">
+            {chatState.isLoading && (
+              <div className="flex items-center space-x-3 text-sm text-gray-600">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span>QWEN 正在思考并协调工具...</span>
+              </div>
+            )}
+
+            <div ref={messagesEndRef} />
+          </main>
+
+          <footer className="border-t border-gray-200 bg-white px-4 py-3">
             <input
-              ref={fileInputRef}
               type="file"
+              ref={fileInputRef}
+              className="hidden"
               multiple
               onChange={handleFileUpload}
-              className="hidden"
-              accept=".txt,.pdf,.doc,.docx,.csv,.xlsx"
             />
-            
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              className="p-2 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100"
-              disabled={isLoading}
-            >
-              <Paperclip className="w-5 h-5" />
-            </button>
-            
-            <button
-              onClick={handleVoiceInput}
-              className={clsx(
-                'p-2 rounded-md transition-colors',
-                isRecording
-                  ? 'text-red-600 bg-red-100 hover:bg-red-200'
-                  : 'text-gray-400 hover:text-gray-600 hover:bg-gray-100'
-              )}
-              disabled={isLoading}
-            >
-              {isRecording ? (
-                <MicOff className="w-5 h-5" />
-              ) : (
-                <Mic className="w-5 h-5" />
-              )}
-            </button>
-            
-            <button
-              onClick={handleSendMessage}
-              disabled={!input.trim() || isLoading}
-              className="p-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              <Send className="w-5 h-5" />
-            </button>
-          </div>
+            <div className="flex items-end space-x-3">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="p-2 rounded-lg text-gray-500 hover:text-gray-700 hover:bg-gray-100"
+                title="上传附件"
+              >
+                <Paperclip className="w-5 h-5" />
+              </button>
+
+              <button
+                type="button"
+                onClick={handleVoiceInput}
+                className={clsx(
+                  'p-2 rounded-lg transition-colors',
+                  isRecording
+                    ? 'bg-red-100 text-red-600 hover:bg-red-200'
+                    : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+                )}
+                title={isRecording ? '停止录音' : '语音输入'}
+              >
+                {isRecording ? <Square className="w-5 h-5" /> : <Mic className="w-5 h-5" />}
+              </button>
+
+              <div className="flex-1 relative">
+                <textarea
+                  value={input}
+                  onChange={(event) => setInput(event.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="请输入问题，Enter 发送 / Shift+Enter 换行"
+                  className="w-full resize-none rounded-lg border border-gray-300 px-4 py-3 pr-12 text-sm leading-relaxed focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
+                  rows={2}
+                />
+                <button
+                  type="button"
+                  onClick={handleSend}
+                  disabled={!input.trim() || chatState.isLoading}
+                  className={clsx(
+                    'absolute right-3 bottom-3 inline-flex items-center justify-center rounded-full p-2 text-white shadow-sm transition-colors',
+                    !input.trim() || chatState.isLoading
+                      ? 'bg-gray-300 cursor-not-allowed'
+                      : 'bg-primary-600 hover:bg-primary-700'
+                  )}
+                >
+                  <Send className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+            <div className="mt-2 flex items-center justify-between text-xs text-gray-400">
+              <span>Enter 发送 · Shift+Enter 换行 · 支持文件和语音辅助</span>
+              <span>
+                {agentMode ? 'Agent 模式' : '纯对话'} · {currentModelOption?.name ?? chatState.currentModel}
+              </span>
+            </div>
+          </footer>
         </div>
-        
-        {/* 输入提示 */}
-        <div className="flex items-center justify-between mt-2 text-xs text-gray-500">
-          <span>按 Enter 发送，Shift + Enter 换行</span>
-          <span>{input.length}/4000</span>
+
+        <div className="hidden xl:flex">
+          <KnowledgeGraphPanel className="w-full" />
         </div>
       </div>
     </div>

--- a/apps/web/src/components/KnowledgeGraph/KnowledgeGraphPanel.tsx
+++ b/apps/web/src/components/KnowledgeGraph/KnowledgeGraphPanel.tsx
@@ -1,0 +1,234 @@
+import React, { useState } from 'react';
+import { clsx } from 'clsx';
+import {
+  Network,
+  Search,
+  Loader2,
+  ToggleLeft,
+  ToggleRight,
+  Layers,
+  Link,
+  Sparkles,
+  History,
+  Info,
+  Eraser,
+  AlertCircle,
+} from 'lucide-react';
+import { useKnowledgeGraphService } from '../../hooks/useKnowledgeGraph';
+
+interface KnowledgeGraphPanelProps {
+  className?: string;
+}
+
+const KnowledgeGraphPanel: React.FC<KnowledgeGraphPanelProps> = ({ className }) => {
+  const [query, setQuery] = useState('');
+  const [relation, setRelation] = useState('');
+  const { knowledgeGraph, toggleKnowledgeGraph, searchKnowledgeGraph, selectEntity, resetKnowledgeGraph } =
+    useKnowledgeGraphService();
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    searchKnowledgeGraph({ entity: query, relation });
+  };
+
+  const handleSelectEntity = (entityId: string) => {
+    const entity = knowledgeGraph.searchResults.find((item) => item.id === entityId);
+    if (entity) {
+      selectEntity(entity);
+    }
+  };
+
+  return (
+    <div
+      className={clsx(
+        'flex flex-col h-full bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden',
+        className
+      )}
+    >
+      <div className="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          <div className="w-9 h-9 bg-primary-100 rounded-lg flex items-center justify-center">
+            <Network className="w-4 h-4 text-primary-600" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">知识图谱联动</h3>
+            <p className="text-xs text-gray-500">检索结构化知识，辅助 QWEN 推理</p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => toggleKnowledgeGraph(!knowledgeGraph.enabled)}
+          className={clsx(
+            'inline-flex items-center px-3 py-1 text-xs font-medium rounded-full border transition-colors',
+            knowledgeGraph.enabled
+              ? 'border-primary-200 bg-primary-50 text-primary-700'
+              : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+          )}
+        >
+          {knowledgeGraph.enabled ? (
+            <ToggleRight className="w-4 h-4 mr-1" />
+          ) : (
+            <ToggleLeft className="w-4 h-4 mr-1" />
+          )}
+          {knowledgeGraph.enabled ? '已开启' : '未开启'}
+        </button>
+      </div>
+
+      <div className="p-4 space-y-4 flex-1 overflow-y-auto">
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <label className="text-xs font-medium text-gray-600">实体检索</label>
+          <div className="flex space-x-2">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="输入公司/行业/事件等关键词"
+                className="w-full pl-9 pr-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-100 focus:border-primary-300"
+              />
+            </div>
+            <input
+              value={relation}
+              onChange={(event) => setRelation(event.target.value)}
+              placeholder="关系类型 (可选)"
+              className="w-32 px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-100 focus:border-primary-300"
+            />
+            <button
+              type="submit"
+              className="inline-flex items-center px-3 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700"
+              disabled={knowledgeGraph.loading}
+            >
+              {knowledgeGraph.loading ? <Loader2 className="w-4 h-4 animate-spin" /> : '检索'}
+            </button>
+          </div>
+        </form>
+
+        {knowledgeGraph.error && (
+          <div className="flex items-start space-x-2 p-3 bg-red-50 border border-red-100 rounded-lg text-xs text-red-600">
+            <AlertCircle className="w-4 h-4 mt-0.5" />
+            <div>
+              <p className="font-medium">知识图谱异常</p>
+              <p>{knowledgeGraph.error}</p>
+            </div>
+          </div>
+        )}
+
+        {knowledgeGraph.history.length > 0 && (
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center space-x-2 text-xs text-gray-500">
+                <History className="w-3 h-3" />
+                <span>最近检索</span>
+              </div>
+              <button
+                type="button"
+                onClick={resetKnowledgeGraph}
+                className="inline-flex items-center text-xs text-gray-400 hover:text-gray-600"
+              >
+                <Eraser className="w-3 h-3 mr-1" /> 清空
+              </button>
+            </div>
+            <div className="space-y-1">
+              {knowledgeGraph.history.slice(0, 5).map((item) => (
+                <div key={item.id} className="text-xs text-gray-500 flex items-center justify-between">
+                  <span className="truncate">{item.query}</span>
+                  <span>{new Date(item.timestamp).toLocaleTimeString()}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div>
+          <div className="flex items-center space-x-2 text-xs text-gray-500 mb-2">
+            <Layers className="w-3 h-3" />
+            <span>实体候选</span>
+          </div>
+          {knowledgeGraph.searchResults.length === 0 ? (
+            <p className="text-xs text-gray-400">暂无结果，尝试新的关键词检索。</p>
+          ) : (
+            <div className="space-y-2">
+              {knowledgeGraph.searchResults.slice(0, 10).map((entity) => {
+                const isSelected = knowledgeGraph.selectedEntity?.id === entity.id;
+                return (
+                  <button
+                    type="button"
+                    key={entity.id}
+                    onClick={() => handleSelectEntity(entity.id)}
+                    className={clsx(
+                      'w-full text-left border rounded-lg px-3 py-2',
+                      'transition-colors duration-150',
+                      isSelected
+                        ? 'border-primary-300 bg-primary-50 text-primary-700'
+                        : 'border-gray-200 hover:border-primary-200 hover:bg-primary-50/50'
+                    )}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium">{entity.name}</span>
+                      {typeof entity.score === 'number' && (
+                        <span className="text-xs text-gray-500">置信度 {Math.round(entity.score * 100)}%</span>
+                      )}
+                    </div>
+                    {entity.type && <p className="text-xs text-gray-500">类型：{entity.type}</p>}
+                    {entity.description && (
+                      <p className="text-xs text-gray-500 truncate">{entity.description}</p>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {knowledgeGraph.selectedEntity && (
+          <div className="border border-primary-100 rounded-lg p-3 bg-primary-50/40">
+            <div className="flex items-start space-x-2">
+              <Sparkles className="w-4 h-4 text-primary-500 mt-0.5" />
+              <div>
+                <div className="flex items-center justify-between">
+                  <h4 className="text-sm font-semibold text-primary-700">已选实体</h4>
+                  <span className="text-xs text-primary-600">
+                    {knowledgeGraph.relations.length} 条关系已加载
+                  </span>
+                </div>
+                <p className="text-sm text-primary-800 mt-1">{knowledgeGraph.selectedEntity.name}</p>
+                {knowledgeGraph.selectedEntity.description && (
+                  <p className="text-xs text-primary-700 leading-snug mt-1">
+                    {knowledgeGraph.selectedEntity.description}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {knowledgeGraph.relations.length > 0 ? (
+              <div className="mt-3 space-y-1 max-h-40 overflow-y-auto pr-1">
+                {knowledgeGraph.relations.slice(0, 20).map((relation) => (
+                  <div
+                    key={relation.id}
+                    className="flex items-center justify-between text-xs text-primary-700 bg-white/70 rounded px-2 py-1"
+                  >
+                    <span className="truncate">{relation.source}</span>
+                    <Link className="w-3 h-3 text-primary-500 mx-1" />
+                    <span className="truncate">{relation.target}</span>
+                    <span className="ml-2 text-[11px] text-primary-500">{relation.type}</span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-primary-600 mt-2">未检索到关系，可尝试指定关系类型。</p>
+            )}
+          </div>
+        )}
+
+        <div className="flex items-start space-x-2 text-xs text-gray-400 bg-gray-50 border border-gray-100 rounded-lg p-3">
+          <Info className="w-4 h-4" />
+          <p>
+            开启知识图谱后，系统会在调用 QWEN 进行推理时注入结构化实体与关系上下文，帮助模型生成更可靠的投资分析。
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default KnowledgeGraphPanel;

--- a/apps/web/src/hooks/useChatService.ts
+++ b/apps/web/src/hooks/useChatService.ts
@@ -1,0 +1,253 @@
+import { useCallback, useMemo, useState } from 'react';
+import apiService from '../services/api';
+import {
+  useChat,
+  useChatActions,
+  type ChatMessage,
+  type LLMModelOption,
+  type KnowledgeGraphContextPayload,
+} from '../store';
+
+interface SendAgentMessageOptions {
+  agentMode?: boolean;
+  knowledgeGraph?: KnowledgeGraphContextPayload;
+  stream?: boolean;
+}
+
+interface ModelTestResult {
+  provider: string;
+  success: boolean;
+  timestamp: string;
+  message?: string;
+}
+
+const FALLBACK_MODELS: LLMModelOption[] = [
+  {
+    id: 'qwen:qwen2.5-14b',
+    name: 'Qwen2.5 14B',
+    provider: 'qwen',
+    model: 'qwen2.5-14b-instruct',
+    context: '128K',
+    description: '通义千问2.5 14B 指令微调模型',
+    capabilities: ['analysis', 'reasoning', 'chinese'],
+    streaming: true,
+    status: 'online',
+  },
+  {
+    id: 'qwen:qwen2.5-32b',
+    name: 'Qwen2.5 32B',
+    provider: 'qwen',
+    model: 'qwen2.5-32b-instruct',
+    context: '256K',
+    description: '通义千问2.5 32B 长上下文版本',
+    capabilities: ['long-context', 'analysis'],
+    streaming: true,
+    status: 'online',
+  },
+];
+
+const normalizeModel = (item: unknown, index: number): LLMModelOption => {
+  if (typeof item === 'string') {
+    const [provider, model] = item.includes(':') ? item.split(':') : ['custom', item];
+    return {
+      id: `${provider}:${model}`,
+      name: model,
+      provider,
+      model,
+      context: '未知',
+      description: '后端返回的模型',
+      status: 'online',
+    };
+  }
+
+  if (!item || typeof item !== 'object') {
+    return {
+      id: `fallback:${index}`,
+      name: `模型${index + 1}`,
+      provider: 'custom',
+      model: `model_${index}`,
+      context: '未知',
+      description: '未识别的模型定义',
+      status: 'online',
+    };
+  }
+
+  const record = item as Record<string, unknown>;
+  const provider = (record.provider as string | undefined) ?? (record.vendor as string | undefined) ?? 'custom';
+  const model = (record.model as string | undefined) ?? (record.name as string | undefined) ?? `model_${index}`;
+
+  return {
+    id: (record.id as string | undefined) ?? `${provider}:${model}`,
+    name: (record.name as string | undefined) ?? (model as string),
+    provider,
+    model: model as string,
+    context: (record.context as string | undefined) ?? (record.max_context as string | undefined) ?? '未知',
+    description: (record.description as string | undefined) ?? (record.summary as string | undefined),
+    capabilities: (record.capabilities as string[] | undefined) ?? (record.features as string[] | undefined),
+    streaming: Boolean(record.streaming ?? record.stream),
+    status: (record.status as LLMModelOption['status']) ?? 'online',
+  };
+};
+
+const normalizeModels = (data: unknown): LLMModelOption[] => {
+  if (!data) return FALLBACK_MODELS;
+  if (Array.isArray(data)) {
+    const normalized = data.map((item, index) => normalizeModel(item, index));
+    return normalized.length > 0 ? normalized : FALLBACK_MODELS;
+  }
+  if (typeof data === 'object') {
+    const values = Object.values(data as Record<string, unknown>);
+    if (values.length > 0) {
+      return values.map((value, index) => normalizeModel(value, index));
+    }
+  }
+  return FALLBACK_MODELS;
+};
+
+export const useChatService = () => {
+  const chatState = useChat();
+  const { addMessage, clearMessages, setLoading, setCurrentModel, setAvailableModels } = useChatActions();
+  const [modelTests, setModelTests] = useState<Record<string, ModelTestResult>>({});
+
+  const currentModelOption = useMemo(
+    () =>
+      chatState.availableModels.find(
+        (model) => model.model === chatState.currentModel || model.id === chatState.currentModel
+      ),
+    [chatState.availableModels, chatState.currentModel]
+  );
+
+  const loadAvailableModels = useCallback(async () => {
+    try {
+      const response = await apiService.getAvailableModels();
+      if (response.status === 'ok') {
+        const models = normalizeModels(response.data);
+        setAvailableModels(models);
+        if (!models.find((model) => model.model === chatState.currentModel)) {
+          setCurrentModel(models[0]?.model ?? chatState.currentModel);
+        }
+        return models;
+      }
+
+      const fallback = normalizeModels(undefined);
+      setAvailableModels(fallback);
+      return fallback;
+    } catch (error: unknown) {
+      console.error('Failed to load models, using fallback', error);
+      const fallback = normalizeModels(undefined);
+      setAvailableModels(fallback);
+      if (!fallback.find((model) => model.model === chatState.currentModel)) {
+        setCurrentModel(fallback[0]?.model ?? chatState.currentModel);
+      }
+      return fallback;
+    }
+  }, [chatState.currentModel, setAvailableModels, setCurrentModel]);
+
+  const testModelConnection = useCallback(
+    async (provider: string) => {
+      const timestamp = new Date().toISOString();
+      try {
+        const response = await apiService.testModelConnection(provider);
+        const success = response.status === 'ok';
+        const result: ModelTestResult = {
+          provider,
+          success,
+          timestamp,
+          message: response.message || response.data?.message,
+        };
+        setModelTests((prev) => ({ ...prev, [provider]: result }));
+        return result;
+      } catch (error: unknown) {
+        const result: ModelTestResult = {
+          provider,
+          success: false,
+          timestamp,
+          message: error instanceof Error ? error.message : '连接测试失败',
+        };
+        setModelTests((prev) => ({ ...prev, [provider]: result }));
+        return result;
+      }
+    },
+    []
+  );
+
+  const sendAgentMessage = useCallback(
+    async (content: string, options?: SendAgentMessageOptions) => {
+      const trimmedContent = content.trim();
+      if (!trimmedContent) return;
+
+      const userMessage: Omit<ChatMessage, 'id' | 'timestamp'> = {
+        type: 'user',
+        content: trimmedContent,
+      };
+      addMessage(userMessage);
+      setLoading(true);
+
+      try {
+        const context = (chatState.messages || []).slice(-10).map((message) => ({
+          role: message.type === 'user' ? 'user' : 'assistant',
+          content: message.content,
+        }));
+
+        const response = await apiService.sendAgentMessage({
+          message: trimmedContent,
+          model: chatState.currentModel,
+          provider: chatState.currentProvider,
+          context,
+          tools_enabled: options?.agentMode ?? true,
+          knowledge_graph: options?.knowledgeGraph,
+          stream: options?.stream ?? false,
+        });
+
+        if (response.status === 'ok' && response.data) {
+          const assistantMessage: Omit<ChatMessage, 'id' | 'timestamp'> = {
+            type: 'assistant',
+            content: response.data.message ?? response.data.content ?? '',
+            metadata: {
+              model: response.data.model ?? chatState.currentModel,
+              provider: response.data.provider ?? chatState.currentProvider,
+              tokens: response.data.tokens_used ?? response.data.usage?.total_tokens,
+              execution_time: response.data.execution_time ?? response.data.latency,
+              tools_used: Array.isArray(response.data.tools_used)
+                ? response.data.tools_used
+                : undefined,
+              cost: response.data.cost,
+              confidence: response.data.confidence,
+            },
+          };
+          addMessage(assistantMessage);
+        } else {
+          const errorMessage: Omit<ChatMessage, 'id' | 'timestamp'> = {
+            type: 'system',
+            content: `Agent返回错误：${response.error || response.message || '未知错误'}`,
+          };
+          addMessage(errorMessage);
+        }
+      } catch (error: unknown) {
+        console.error('Failed to send agent message:', error);
+        const errorMessage: Omit<ChatMessage, 'id' | 'timestamp'> = {
+          type: 'system',
+          content: `发送失败：${error instanceof Error ? error.message : '请检查网络或Agent服务状态'}`,
+        };
+        addMessage(errorMessage);
+        throw error;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [addMessage, chatState.currentModel, chatState.currentProvider, chatState.messages, setLoading]
+  );
+
+  return {
+    chatState,
+    currentModelOption,
+    modelTests,
+    loadAvailableModels,
+    testModelConnection,
+    sendAgentMessage,
+    clearMessages,
+    setCurrentModel,
+  };
+};
+
+export type { SendAgentMessageOptions, ModelTestResult };

--- a/apps/web/src/hooks/useKnowledgeGraph.ts
+++ b/apps/web/src/hooks/useKnowledgeGraph.ts
@@ -1,0 +1,229 @@
+import { useCallback } from 'react';
+import apiService from '../services/api';
+import {
+  useKnowledgeGraph,
+  useKnowledgeGraphActions,
+  type KnowledgeGraphContextPayload,
+  type KnowledgeGraphEntity,
+  type KnowledgeGraphRelation,
+} from '../store';
+
+const normalizeEntity = (item: unknown): KnowledgeGraphEntity => {
+  if (!item || typeof item !== 'object') {
+    return {
+      id: String(item ?? `entity_${Date.now()}`),
+      name: String(item ?? '未知实体'),
+    };
+  }
+
+  const record = item as Record<string, unknown>;
+
+  return {
+    id:
+      (record.id as string | undefined) ??
+      (record.entity_id as string | undefined) ??
+      (record.identifier as string | undefined) ??
+      (record.name as string | undefined) ??
+      `entity_${Date.now()}`,
+    name:
+      (record.name as string | undefined) ??
+      (record.label as string | undefined) ??
+      (record.title as string | undefined) ??
+      '未知实体',
+    type: (record.type as string | undefined) ?? (record.category as string | undefined) ?? (record.kind as string | undefined),
+    description:
+      (record.description as string | undefined) ??
+      (record.summary as string | undefined) ??
+      (record.brief as string | undefined),
+    attributes:
+      (record.attributes as Record<string, unknown> | undefined) ??
+      (record.metadata as Record<string, unknown> | undefined) ??
+      (record.properties as Record<string, unknown> | undefined),
+    score:
+      (record.score as number | undefined) ??
+      (record.weight as number | undefined) ??
+      (record.confidence as number | undefined),
+  };
+};
+
+const normalizeRelation = (item: unknown): KnowledgeGraphRelation => {
+  if (!item || typeof item !== 'object') {
+    const id = String(item ?? `relation_${Date.now()}`);
+    return {
+      id,
+      source: id,
+      target: id,
+      type: 'related_to',
+    };
+  }
+
+  const record = item as Record<string, unknown>;
+  const source =
+    (record.source as string | undefined) ??
+    (record.from as string | undefined) ??
+    (record.head as string | undefined) ??
+    (record.entity_a as string | undefined) ??
+    '';
+  const target =
+    (record.target as string | undefined) ??
+    (record.to as string | undefined) ??
+    (record.tail as string | undefined) ??
+    (record.entity_b as string | undefined) ??
+    '';
+  const type =
+    (record.type as string | undefined) ??
+    (record.relation as string | undefined) ??
+    (record.edge_type as string | undefined) ??
+    'related_to';
+
+  return {
+    id: (record.id as string | undefined) ?? `${source}-${type}-${target}`,
+    source,
+    target,
+    type,
+    weight:
+      (record.weight as number | undefined) ??
+      (record.score as number | undefined) ??
+      (record.probability as number | undefined),
+    metadata:
+      (record.metadata as Record<string, unknown> | undefined) ??
+      (record.attributes as Record<string, unknown> | undefined) ??
+      (record.details as Record<string, unknown> | undefined),
+  };
+};
+
+export const useKnowledgeGraphService = () => {
+  const knowledgeGraph = useKnowledgeGraph();
+  const {
+    setKnowledgeGraphEnabled,
+    setKnowledgeGraphLoading,
+    setKnowledgeGraphError,
+    setKnowledgeGraphResults,
+    setKnowledgeGraphSelectedEntity,
+    setKnowledgeGraphRelations,
+    addKnowledgeGraphHistory,
+    clearKnowledgeGraph,
+  } = useKnowledgeGraphActions();
+
+  const toggleKnowledgeGraph = useCallback(
+    (enabled: boolean) => {
+      setKnowledgeGraphEnabled(enabled);
+    },
+    [setKnowledgeGraphEnabled]
+  );
+
+  const searchKnowledgeGraph = useCallback(
+    async (query: { entity?: string; relation?: string; limit?: number }) => {
+      const searchTerm = query.entity?.trim();
+      if (!searchTerm) {
+        setKnowledgeGraphError('请输入要检索的实体名称');
+        return;
+      }
+
+      setKnowledgeGraphLoading(true);
+      setKnowledgeGraphError(null);
+
+      try {
+        const response = await apiService.searchKnowledgeGraph({
+          entity: searchTerm,
+          relation: query.relation,
+          limit: query.limit ?? 20,
+        });
+
+        if (response.status === 'ok' && Array.isArray(response.data)) {
+          const results = response.data.map(normalizeEntity);
+          setKnowledgeGraphResults(results);
+          addKnowledgeGraphHistory({
+            id: `kg_query_${Date.now()}`,
+            query: searchTerm,
+            relation: query.relation,
+            timestamp: new Date().toISOString(),
+            results: results.length,
+          });
+          if (results.length > 0) {
+            setKnowledgeGraphSelectedEntity(results[0]);
+          }
+        } else {
+          setKnowledgeGraphError(response.error || '知识图谱查询失败');
+          setKnowledgeGraphResults([]);
+        }
+      } catch (error: unknown) {
+        console.error('Knowledge graph search failed:', error);
+        setKnowledgeGraphError(error instanceof Error ? error.message : '知识图谱服务不可用');
+        setKnowledgeGraphResults([]);
+      } finally {
+        setKnowledgeGraphLoading(false);
+      }
+    },
+    [addKnowledgeGraphHistory, setKnowledgeGraphError, setKnowledgeGraphLoading, setKnowledgeGraphResults, setKnowledgeGraphSelectedEntity]
+  );
+
+  const selectEntity = useCallback(
+    async (entity: KnowledgeGraphEntity) => {
+      if (!entity?.id) {
+        setKnowledgeGraphSelectedEntity(undefined);
+        setKnowledgeGraphRelations([]);
+        return;
+      }
+
+      setKnowledgeGraphLoading(true);
+      setKnowledgeGraphError(null);
+
+      try {
+        const [detailResponse, relationsResponse] = await Promise.all([
+          apiService.getEntityDetails(entity.id),
+          apiService.getRelatedEntities(entity.id),
+        ]);
+
+        const entityDetails =
+          detailResponse.status === 'ok' ? { ...entity, ...normalizeEntity(detailResponse.data) } : entity;
+        const relations =
+          relationsResponse.status === 'ok' && Array.isArray(relationsResponse.data)
+            ? relationsResponse.data.map(normalizeRelation)
+            : [];
+
+        setKnowledgeGraphSelectedEntity(entityDetails);
+        setKnowledgeGraphRelations(relations);
+      } catch (error: unknown) {
+        console.error('Failed to load entity details:', error);
+        setKnowledgeGraphError(error instanceof Error ? error.message : '获取实体详情失败');
+        setKnowledgeGraphSelectedEntity(entity);
+      } finally {
+        setKnowledgeGraphLoading(false);
+      }
+    },
+    [setKnowledgeGraphError, setKnowledgeGraphLoading, setKnowledgeGraphRelations, setKnowledgeGraphSelectedEntity]
+  );
+
+  const resetKnowledgeGraph = useCallback(() => {
+    clearKnowledgeGraph();
+  }, [clearKnowledgeGraph]);
+
+  const getKnowledgeGraphContext = useCallback((): KnowledgeGraphContextPayload => {
+    if (!knowledgeGraph.enabled) {
+      return { enabled: false };
+    }
+
+    const focusEntity = knowledgeGraph.selectedEntity;
+    const entities = focusEntity ? [focusEntity] : knowledgeGraph.searchResults.slice(0, 5);
+    const relations = knowledgeGraph.relations.slice(0, 20);
+
+    return {
+      enabled: true,
+      focus: focusEntity?.name ?? knowledgeGraph.searchResults[0]?.name,
+      entities,
+      relations,
+    };
+  }, [knowledgeGraph.enabled, knowledgeGraph.relations, knowledgeGraph.searchResults, knowledgeGraph.selectedEntity]);
+
+  return {
+    knowledgeGraph,
+    toggleKnowledgeGraph,
+    searchKnowledgeGraph,
+    selectEntity,
+    resetKnowledgeGraph,
+    getKnowledgeGraphContext,
+  };
+};
+
+export type { KnowledgeGraphEntity, KnowledgeGraphRelation, KnowledgeGraphContextPayload };

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -317,8 +317,15 @@ class ApiService {
   async sendAgentMessage(data: {
     message: string;
     model?: string;
-    context?: Array<{role: string; content: string}>;
+    provider?: string;
+    context?: Array<{ role: string; content: string }>;
     tools_enabled?: boolean;
+    knowledge_graph?: {
+      enabled: boolean;
+      focus?: string;
+      entities?: any[];
+      relations?: any[];
+    };
     stream?: boolean;
   }): Promise<ApiResponse<any>> {
     return this.post('/agent/chat', data);
@@ -351,7 +358,7 @@ class ApiService {
   }
 
   // 获取可用模型
-  async getAvailableModels(): Promise<ApiResponse<string[]>> {
+  async getAvailableModels(): Promise<ApiResponse<any>> {
     return this.get('/models/available');
   }
 


### PR DESCRIPTION
## Summary
- extend the Zustand chat state with QWEN model metadata and persistent knowledge-graph state, including new actions for enabling, loading and recording graph context
- add chat and knowledge-graph service hooks plus a reusable model selector to fetch available providers, test QWEN connectivity and assemble graph context for agent calls
- rebuild the enhanced chat UI with QWEN-aware settings, agent mode toggles and a responsive knowledge-graph side panel that surfaces entity search, history and relation details

## Testing
- `npm run lint`
- `npx eslint src/components/Chat/EnhancedChatInterface.tsx src/hooks/useChatService.ts src/hooks/useKnowledgeGraph.ts src/components/Chat/ChatModelSelector.tsx src/components/KnowledgeGraph/KnowledgeGraphPanel.tsx`
- `npx eslint src/components/Chat/ChatInterface.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68cf71b6ca0c83258b0dd58473743ca9